### PR TITLE
Add section about using Airbnb linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@
 
 ## Documentation
 
-ESDoc extends JSDoc with support for ES6 syntax, gives document coverage(think code coverage for documentation) and generates nice HTML documentation in a navigable format. 
+ESDoc extends JSDoc with support for ES6 syntax, gives document coverage(think code coverage for documentation) and generates nice HTML documentation in a navigable format.
 
 ## Project Tooling
+
+### Linters
+
+It's important to use a linter with reasonable configurations to catch common errors before running your code. We are basing our ESLint configurations off of Airbnb's linters which can be found [here](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb).
 
 ## Debugging
 
@@ -33,7 +37,7 @@ ESDoc extends JSDoc with support for ES6 syntax, gives document coverage(think c
 
 ## Team Communication
 
-MVS (Minimum Viable Scrum) - Daily communication with internal team is critical. Meetings suck. And in the environment we work in, even harder they can be hard to schedule with everyone's schedule. 
+MVS (Minimum Viable Scrum) - Daily communication with internal team is critical. Meetings suck. And in the environment we work in, even harder they can be hard to schedule with everyone's schedule.
 
 MVS can be defined as follows:
 - Check in via chat in the morning on what you will be doing today


### PR DESCRIPTION
Do we even use jshint anymore? Or is it all eslint from now on?

I just set up a project using Airbnb's eslint and babelrc files, very simple to set up since they manage it through npm and it can easily be updated and moved between projects.

Not to make more work for ourselves, but if we do start creating our own rules we could set up our own version that pulls in their project and extends it (`eslint-config-sudokrew`)?
https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb
